### PR TITLE
Update SNUnit and fix application hanging on startup

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ import scala.scalanative.build.Mode
 val V = new {
   val Scala = "3.3.0"
 
-  val snunit = "0.5.5"
+  val snunit = "0.7.0"
 
   val snCrypto = "0.0.4"
 
@@ -203,12 +203,17 @@ def unitConfig(
     },
     "web": {
       "processes": {
-        "max": 10
+        "max": 10,
+        "idle_timeout": 180
       },
       "type": "external",
       "executable": "$webPath",
       "environment": {
         "WORKER_HOST": "http://localhost:8888"
+      },
+      "limits": {
+        "timeout": 1,
+        "requests": 1000
       }
     }
   }

--- a/build.sbt
+++ b/build.sbt
@@ -203,17 +203,12 @@ def unitConfig(
     },
     "web": {
       "processes": {
-        "max": 10,
-        "idle_timeout": 180
+        "max": 10
       },
       "type": "external",
       "executable": "$webPath",
       "environment": {
         "WORKER_HOST": "http://localhost:8888"
-      },
-      "limits": {
-        "timeout": 1,
-        "requests": 1000
       }
     }
   }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.4.12")
+addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.4.14")
 addSbtPlugin("com.indoorvivants.vcpkg" % "sbt-vcpkg-native" % "0.0.11")
 addSbtPlugin("com.disneystreaming.smithy4s" % "smithy4s-sbt-codegen" % "0.17.6")
 resolvers += Resolver.sonatypeRepo("snapshots")


### PR DESCRIPTION
Update Scala Native to 0.4.14

SNUnit 0.7.0 should fix the lifecycle problems in Cats Effect applications.
Tested on my machine and now the health endpoint works correctly.